### PR TITLE
Add rating summary to team builder

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -1175,6 +1175,18 @@ body::before {
   box-shadow: 0 4px 15px rgba(149, 165, 166, 0.2);
 }
 
+.rating-summary {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  background: rgba(255, 255, 255, 0.15);
+  padding: 0.5rem 1rem;
+  border-radius: 12px;
+  font-weight: 600;
+  color: #ffd700;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.2);
+}
+
 /* Players section header and filters */
 .players-header {
   margin-bottom: 1.5rem;

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -400,6 +400,15 @@ const App = () => {
     return Object.values(assignedPlayers).map(player => player.id);
   };
 
+  const totalRating = Object.values(assignedPlayers).reduce(
+    (sum, player) => sum + player.rating,
+    0
+  );
+  const averageRating =
+    Object.values(assignedPlayers).length > 0
+      ? (totalRating / Object.values(assignedPlayers).length).toFixed(1)
+      : 0;
+
   const availablePlayers = players.filter(player => 
     !getAssignedPlayerIds().includes(player.id)
   );
@@ -494,13 +503,19 @@ const App = () => {
                   🗑️ Limpiar
                 </button>
                 
-                <button 
+                <button
                   className="save-btn"
                   onClick={() => setShowSaveModal(true)}
                   disabled={Object.keys(assignedPlayers).length === 0}
                 >
                   💾 Guardar Formación
                 </button>
+
+                {Object.values(assignedPlayers).length > 0 && (
+                  <div className="rating-summary">
+                    ⭐ Promedio: {averageRating}
+                  </div>
+                )}
               </div>
 
               <FootballField


### PR DESCRIPTION
## Summary
- compute total and average rating of assigned players
- show rating summary next to save formation button
- style the rating summary widget

## Testing
- `pytest -q` *(fails: ConnectionError because backend API is not running)*

------
https://chatgpt.com/codex/tasks/task_e_6861f015f640832f9d064e2900644e24