### PR TITLE
Add reduced-motion toggle

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -4,6 +4,34 @@
   box-sizing: border-box;
 }
 
+/* Disable animations if user prefers reduced motion or toggle is active */
+@media (prefers-reduced-motion: reduce) {
+  * {
+    animation: none !important;
+    transition: none !important;
+  }
+}
+
+.reduce-motion * {
+  animation: none !important;
+  transition: none !important;
+}
+
+.motion-toggle {
+  margin-left: auto;
+  padding: 0.5rem 1rem;
+  background: linear-gradient(135deg, #444, #666);
+  color: white;
+  border: none;
+  border-radius: 20px;
+  cursor: pointer;
+  font-size: 0.9rem;
+}
+
+.motion-toggle:hover {
+  background: linear-gradient(135deg, #555, #777);
+}
+
 @import url('https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;500;600;700;800&display=swap');
 
 body {

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -146,6 +146,7 @@ const App = () => {
   const [showSaveModal, setShowSaveModal] = useState(false);
   const [showThemeSelector, setShowThemeSelector] = useState(false);
   const [showRankings, setShowRankings] = useState(false);
+  const [reduceMotion, setReduceMotion] = useState(false);
   const [playerFilters, setPlayerFilters] = useState({
     position: '',
     club: '',
@@ -429,12 +430,12 @@ const App = () => {
   }
 
   return (
-    <div className="app">
+    <div className={`app ${reduceMotion ? 'reduce-motion' : ''}`}>
       <header className="app-header">
         <h1>⚽ Once Ideal</h1>
         
         <nav className="main-nav">
-          <button 
+          <button
             className={currentView === 'builder' ? 'active' : ''}
             onClick={() => setCurrentView('builder')}
           >
@@ -451,6 +452,12 @@ const App = () => {
             onClick={() => setCurrentView('themes')}
           >
             🎯 Temas
+          </button>
+          <button
+            className="motion-toggle"
+            onClick={() => setReduceMotion(!reduceMotion)}
+          >
+            {reduceMotion ? 'Activar Animaciones' : 'Desactivar Animaciones'}
           </button>
         </nav>
 


### PR DESCRIPTION
## Summary
- allow disabling CSS animations via toggle or OS setting

## Testing
- `pytest -q` *(fails: ConnectionError: HTTPConnectionPool(host='localhost', port=8001))*

------
https://chatgpt.com/codex/tasks/task_e_6861f277a1d8832fb2d8dec1de2a72e5